### PR TITLE
Add a little color to linkbot - '$ green GOOD TO GO'

### DIFF
--- a/plugins/colors.rb
+++ b/plugins/colors.rb
@@ -1,0 +1,36 @@
+class Colors < Linkbot::Plugin
+
+  ESC = "\033"
+
+  COLORS = {
+    "black" => "30m",
+    "red" => "31m",
+    "green" => "32m",
+    "yellow" => "33m",
+    "blue" => "34m",
+    "magenta" => "35m",
+    "cyan" => "36m",
+    "white" => "39m"
+    }
+
+  def self.on_message(message, matches)
+    color, text = self.parse_color_and_text_from message.body
+    colorize(color, text)
+  end
+
+  def self.parse_color_and_text_from msg
+    msg.scan(/^#{self.colors_regex} (.*)/)[0]
+  end
+
+  def self.colorize color, text
+    "#{ESC}[#{COLORS[color]}#{text}#{ESC}[#{COLORS['white']}"
+  end
+
+  def self.colors_regex
+    "(#{COLORS.keys.join('|')})"
+  end
+
+  Linkbot::Plugin.register('colors', self, {
+    :message => {:regex => /^#{self.colors_regex}/, :handler => :on_message}
+  })
+end


### PR DESCRIPTION
In Linkbot, print messages in color when in an ANSI-compatible shell.
## Usage

```
$ green Hellz yeah!
=> Hellz yeah!
$ red I don't think so.
=> I don't think so. 
```
## Supported colors
- black
- red
- green
- yellow
- blue
- magenta
- cyan
- white
