### PR TITLE
Add !bikeshed command to resolve the great debate

### DIFF
--- a/plugins/bikeshed.rb
+++ b/plugins/bikeshed.rb
@@ -12,7 +12,7 @@ class Bikeshed < Linkbot::Plugin
 
   def self.on_message(message, matches)
     colour = Nokogiri::XML(open('http://www.colourlovers.com/api/colors/random'))
-    colour.xpath('//badgeUrl').children.first.content
+    colour.css("badgeUrl").children.first.content
   end
 end
 


### PR DESCRIPTION
Returns a URL to a color badge like: 

![image](https://f.cloud.github.com/assets/517302/2002771/a38ed344-860e-11e3-8f82-c99d8b9b7e40.png)
