### PR TITLE
Upgrade eventmachine so’s to work with Ruby 2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,9 +36,14 @@ GEM
       eventmachine
     em-socksify (0.3.0)
       eventmachine (>= 1.0.0.beta.4)
-    eventmachine (1.0.3)
+    eventmachine (1.0.7)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.9.1)
+      faraday (>= 0.7.4, < 0.10)
+    faye-websocket (0.9.2)
+      eventmachine (>= 0.12.0)
+      websocket-driver (>= 0.5.1)
     hpricot (0.8.6)
     htmlentities (4.3.1)
     http_parser.rb (0.5.3)
@@ -51,6 +56,7 @@ GEM
     method_source (0.8.2)
     mini_portile (0.6.0)
     minitest (5.4.0)
+    multi_json (1.11.0)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nokogiri (1.6.3.1)
@@ -73,6 +79,11 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
+    slack-api (1.1.0)
+      faraday (>= 0.7, <= 0.9)
+      faraday_middleware (~> 0.8)
+      faye-websocket (~> 0.9.2)
+      multi_json (~> 1.0, >= 1.0.3)
     slop (3.6.0)
     sqlite3 (1.3.9)
     stemmer (1.0.1)
@@ -87,6 +98,9 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uri_template (0.5.3)
+    websocket-driver (0.5.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
 
 PLATFORMS
   ruby
@@ -107,6 +121,7 @@ DEPENDENCIES
   rack
   sanitize
   sinatra
+  slack-api
   sqlite3
   thin
   twss


### PR DESCRIPTION
In as much as we have a test suite, these new gem versions work against Ruby 2.1.6 and 2.2.2.