### PR TITLE
Ensure image URLs returned end with a graphic extension

### DIFF
--- a/plugins/image.rb
+++ b/plugins/image.rb
@@ -57,7 +57,7 @@ class Image < Linkbot::Plugin
 
     return "No images found. Lame." if imgs.empty?
 
-    url = imgs.sample
+    url = ensure_image_extension imgs.sample
 
     if ::Util.wallpaper?(url)
       url = [url, "(dealwithit) WALLPAPER WALLPAPER WALLPAPER (dealwithit)"]
@@ -68,6 +68,15 @@ class Image < Linkbot::Plugin
 
   def self.help
     "!image [searchity search] - Return a relevant picture"
+  end
+
+  def self.ensure_image_extension(url)
+    ext = url.split('.').pop()
+    if ext =~ /(png|jpe?g|gif)$/i
+      url
+    else
+      "#{url}#.png"
+    end
   end
 end
 


### PR DESCRIPTION
Lifted liberally from [hubot's Google image search](https://github.com/hubot-scripts/hubot-google-images/blob/v0.1.4/src/google-images.coffee#L46-L51). Blindly appends
a graphic extension to a URL if it does not end in one so that chat
clients attempt to treat the URL as a graphic.

Does not solve the problem of Google returning a URL with junk at the
end that causes the real site to go WTF?