### PR TITLE
How about some permissions tests?

### DIFF
--- a/spec/plugins_spec.rb
+++ b/spec/plugins_spec.rb
@@ -5,6 +5,8 @@ describe Linkbot::Plugin do
     Linkbot::Plugin.collect([PLUGIN_PATH])
   end
 
+  let (:message) { Message.new("text", 1, "user", nil, :message, {room: "this_room"}) }
+
   it "has the correct plugin" do
     expect(Linkbot::Plugin.plugins.keys.length).to eq 1
     expect(Linkbot::Plugin.plugins['mock'][:ptr]).to eq MockPlugin
@@ -13,10 +15,74 @@ describe Linkbot::Plugin do
 
   it "handles a message" do
     plugin = Linkbot::Plugin.plugins['mock'][:ptr]
-    response = Linkbot::Message.handle(Message.new("text", 1, "user", nil, :message, {}))
+    response = Linkbot::Message.handle(message)
 
     expect(plugin.messages.length).to eq 1
     expect(plugin.messages[0].body).to eq "text"
     expect(response).to eq ['text']
   end
+
+  context "has permission" do
+
+    it "when there is no room associated with a message" do
+      message.options = {}
+
+      expect(Linkbot::Plugin.has_permission?(message)).to be true
+    end
+
+    it "when no explicit permissions are set" do
+      ::Linkbot::Config["permissions"] = nil
+
+      expect(Linkbot::Plugin.has_permission?(message)).to be true
+    end
+
+    it "when permissions are set, but not for this room" do
+      ::Linkbot::Config["permissions"] = {
+        "not_this_room" => { "whitelist" => ["not_this_plugin"] } }
+
+      expect(Linkbot::Plugin.has_permission?(message)).to be true
+    end
+
+    it "when this room whitelists this plugin" do
+      ::Linkbot::Config["permissions"] = {
+        "this_room" => { "whitelist" => ["Linkbot::Plugin"] } }
+
+      expect(Linkbot::Plugin.has_permission?(message)).to be true
+    end
+
+    it "when this room blacklists other plugins, but not this one" do
+      ::Linkbot::Config["permissions"] = {
+        "this_room" => { "blacklist" => ["some", "other", "plugins"] } }
+
+      expect(Linkbot::Plugin.has_permission?(message)).to be true
+    end
+
+    it "when this room both whitelists and blacklists this plugin" do
+      ::Linkbot::Config["permissions"] = {
+        "this_room" => { "whitelist" => ["Linkbot::Plugin"],
+                         "blacklist" => ["Linkbot::Plugin"] } }
+      expect(Linkbot::Plugin.has_permission?(message)).to be true
+    end
+
+  end
+
+  context "does not have permission" do
+
+    it "when this room whitelists other plugins, but not this one" do
+      ::Linkbot::Config["permissions"] = {
+        "this_room" => { "whitelist" => ["some", "other", "plugins"] } }
+
+      expect(Linkbot::Plugin.has_permission?(message)).to be false
+    end
+
+
+    it "when this room blacklists this plugin" do
+      ::Linkbot::Config["permissions"] = {
+        "this_room" => { "blacklist" => ["Linkbot::Plugin"] } }
+
+      expect(Linkbot::Plugin.has_permission?(message)).to be false
+    end
+
+  end
+
 end


### PR DESCRIPTION
```
±plugin_permission_tests⚡ » be rspec spec --format documentation
Linkbot::Plugin
  has the correct plugin
  handles a message
  has permission
    when there is no room associated with a message
    when no explicit permissions are set
    when permissions are set, but not for this room
    when this room whitelists this plugin
    when this room blacklists other plugins, but not this one
    when this room both whitelists and blacklists this plugin
  does not have permission
    when this room whitelists other plugins, but not this one
    when this room blacklists this plugin

Finished in 0.04198 seconds (files took 1.36 seconds to load)
10 examples, 0 failures
```