### PR TITLE
Check for regex during plugin register

### DIFF
--- a/lib/linkbot/message.rb
+++ b/lib/linkbot/message.rb
@@ -16,14 +16,12 @@ module Linkbot
 
       final_message = []
 
-      Linkbot::Plugin.plugins.each {|k,plugin|
+      Linkbot::Plugin.plugins.each do |k,plugin|
         next unless plugin[:ptr].has_permission?(message)
         next unless plugin[:ptr].has_handler_for?(message)
 
-        # TODO: Typecheck that :regex is a regex.
-        matches_everything = plugin[:handlers][message.type][:regex].nil?
-        if matches = (matches_everything || plugin[:handlers][message.type][:regex].match(message.body))
-          matches = matches_everything ? nil : matches.to_a.drop(1)
+        if matches = plugin[:handlers][message.type][:regex].match(message.body)
+          matches = matches.to_a.drop(1)
           begin
             output_messages = plugin[:ptr].send(plugin[:handlers][message.type][:handler], message, matches)
             next if output_messages.empty?
@@ -35,7 +33,7 @@ module Linkbot
             puts e.backtrace.join("\n")
           end
         end
-      }
+      end
       final_message
     end
 

--- a/lib/linkbot/plugin.rb
+++ b/lib/linkbot/plugin.rb
@@ -30,6 +30,9 @@ module Linkbot
     end
 
     def self.register(name, s, handlers)
+      handlers.each do |type, options|
+        return if !Regexp.try_convert options[:regex]
+      end
       @@plugins[name] = {:ptr => s, :handlers => handlers}
     end
 

--- a/spec/plugins/mock.rb
+++ b/spec/plugins/mock.rb
@@ -8,11 +8,11 @@ class MockPlugin < Linkbot::Plugin
     @@messages << message
     @@matches << matches
 
-    message.body
+    ["body: #{message.body}", "matches: #{matches.join(', ')}"]
   end
 
   def self.messages; @@messages; end
   def self.matches; @@matches; end
 
-  Linkbot::Plugin.register('mock', self, {:message => {:regex => //, :handler => :on_message, :help => :help}})
+  Linkbot::Plugin.register('mock', self, {:message => {:regex => /(\w+)\s(.*)/, :handler => :on_message, :help => :help}})
 end

--- a/spec/plugins_spec.rb
+++ b/spec/plugins_spec.rb
@@ -22,6 +22,12 @@ describe Linkbot::Plugin do
     expect(response).to eq ['text']
   end
 
+  it "does not register a plugin unless all handlers have regexes" do
+    bad_handler = {:message => { :regex => :not_a_regex, :handler => :no_handler} }
+    expect(Linkbot::Plugin.register('faker', MockPlugin, bad_handler)).to be nil
+    expect(Linkbot::Plugin.plugins.keys).to contain_exactly 'mock'
+  end
+
   context "has permission" do
 
     it "when there is no room associated with a message" do

--- a/spec/plugins_spec.rb
+++ b/spec/plugins_spec.rb
@@ -5,12 +5,12 @@ describe Linkbot::Plugin do
     Linkbot::Plugin.collect([PLUGIN_PATH])
   end
 
-  let (:message) { Message.new("text", 1, "user", nil, :message, {room: "this_room"}) }
+  let (:message) { Message.new("foo bar baz", 1, "user", nil, :message, {room: "this_room"}) }
 
   it "has the correct plugin" do
     expect(Linkbot::Plugin.plugins.keys.length).to eq 1
     expect(Linkbot::Plugin.plugins['mock'][:ptr]).to eq MockPlugin
-    expect(Linkbot::Plugin.plugins['mock'][:handlers]).to eq({:message => {:regex => //, :handler => :on_message, :help => :help}})
+    expect(Linkbot::Plugin.plugins['mock'][:handlers]).to eq({:message => {:regex => /(\w+)\s(.*)/, :handler => :on_message, :help => :help}})
   end
 
   it "handles a message" do
@@ -18,8 +18,8 @@ describe Linkbot::Plugin do
     response = Linkbot::Message.handle(message)
 
     expect(plugin.messages.length).to eq 1
-    expect(plugin.messages[0].body).to eq "text"
-    expect(response).to eq ['text']
+    expect(plugin.messages[0].body).to eq "foo bar baz"
+    expect(response).to eq ["body: foo bar baz", "matches: foo, bar baz"]
   end
 
   it "does not register a plugin unless all handlers have regexes" do


### PR DESCRIPTION
Kill a TODO item: type check message handlers' regex option during plugin registration.

Still TODO
- [ ] log that a plugin was ignored