### PR TITLE
Have the bot appear as Slack bot user, not hard coded as "Linkbot"

### DIFF
--- a/connectors/slack.rb
+++ b/connectors/slack.rb
@@ -58,8 +58,7 @@ class SlackConnector < Linkbot::Connector
         @client.chat_postMessage({
           :channel => options[:room],
           :text => message,
-          :username => "Linkbot",
-          :icon_url => "https://dl.dropboxusercontent.com/u/10931735/bot.png"
+          :as_user => true,
         })
       end
     end

--- a/connectors/slack.rb
+++ b/connectors/slack.rb
@@ -5,6 +5,8 @@ class SlackConnector < Linkbot::Connector
 
   def initialize(options)
     super(options)
+    @options["username"] ||= "Linkbot"
+    @options["icon_url"] ||= "https://dl.dropboxusercontent.com/u/10931735/bot.png"
 
     Slack.configure do |config|
       config.token = @options["token"]
@@ -58,7 +60,8 @@ class SlackConnector < Linkbot::Connector
         @client.chat_postMessage({
           :channel => options[:room],
           :text => message,
-          :as_user => true,
+          :username => @options["username"],
+          :icon_url => @options["icon_url"],
         })
       end
     end


### PR DESCRIPTION
Per https://api.slack.com/methods/chat.postMessage pass `true` to have the
message posted as the authenticated user, in this case, the bot user
associated with the token.

# The Difference

## Before

![screen shot 2015-06-17 at 8 24 17 pm](https://cloud.githubusercontent.com/assets/517302/8221648/ef151c50-152e-11e5-92a7-01db03969987.png)

## After

Given in `config.json`:

```
  "connectors" : [
    { "type": "slack",
      "username": "refactorbot",
...
```

... results in configured username and default icon:
![screen shot 2015-06-18 at 9 28 09 am](https://cloud.githubusercontent.com/assets/517302/8232299/8d692bc2-159c-11e5-81be-a46a93f52ae2.png)

... and ...

```
  "connectors" : [
    {"type": "slack",
      "username": "Hedonist Bender",
      "icon_url": "http://icons.iconarchive.com/icons/pixelpirate/futurama/256/Hedonism-Bot-icon.png",
...
```

... in ...

![screen shot 2015-06-18 at 9 35 45 am](https://cloud.githubusercontent.com/assets/517302/8232407/72f3bbb2-159d-11e5-89fc-68ea5ebc0d34.png)