### PR TITLE
Make sure the users table exists before trying to use it, eh?

### DIFF
--- a/lib/linkbot/db.rb
+++ b/lib/linkbot/db.rb
@@ -9,6 +9,9 @@ module Linkbot
   end
   
   def self.load_users
+    if Linkbot.db.table_info('users').empty?
+      Linkbot.db.execute('CREATE TABLE users (user_id STRING, username TEXT, showname TEXT)');
+    end
     rows = Linkbot.db.execute("select user_id, username from users")
     @@user_ids = Hash[rows]
     @@users = Hash[rows.collect {|a,b| [b,a]}]


### PR DESCRIPTION
What even is schema versioning?

`load_users` appears to be [the first thing Linkbot attempts to do with the database when initializing](https://github.com/markolson/linkbot/blob/mark-refactor/lib/linkbot.rb#L25). So, make sure the table exists then. Repeating the way we do it in plugins.