### PR TITLE
remove byebug from production class

### DIFF
--- a/connectors/irc.rb
+++ b/connectors/irc.rb
@@ -1,6 +1,5 @@
 require "em-irc"
 require "logger"
-require 'byebug'
 
 class IRCConnector < Linkbot::Connector
   Linkbot::Connector.register('irc', self)


### PR DESCRIPTION
Requires readline which requires a Ruby built with readline which requires me to build a Ruby. Don't wanna. Seems we can remove it from the IRC connector at this point.