### PR TITLE
set stdout to sync writes so they don't delay in a buffer

### DIFF
--- a/lib/linkbot/log.rb
+++ b/lib/linkbot/log.rb
@@ -1,7 +1,8 @@
 require 'logger'
 
 module Linkbot
-  @@logger = ::Logger.new(STDOUT)
+  $stdout.sync = true
+  @@logger = ::Logger.new($stdout)
 
   def self.log
     @@logger


### PR DESCRIPTION
Helps with logging actually getting updated with log events when
they happen.