### PR TITLE
reorganize hab build plan

### DIFF
--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -6,7 +6,7 @@ if [ "$(whoami)" = "root" ]; then
   exec chpst \
     -U hab:hab \
     -u hab:hab \
-    bundle exec linkbot --config {{pkg.svc_config_path}}/config.json --database {{pkg.svc_data_path}}/data.sqlite3 2>&1
+    linkbot --config {{pkg.svc_config_path}}/config.json --database {{pkg.svc_data_path}}/data.sqlite3 2>&1
 else
-  exec bundle exec linkbot --config {{pkg.svc_config_path}}/config.json --database {{pkg.svc_data_path}}/data.sqlite3 2>&1
+  exec linkbot --config {{pkg.svc_config_path}}/config.json --database {{pkg.svc_data_path}}/data.sqlite3 2>&1
 fi

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -84,11 +84,11 @@ do_prepare() {
 
 
 do_build() {
+  build_line "** install matching version of bundler"
+  gem install bundler -v "$(grep -A1 "BUNDLED WITH" Gemfile.lock | tail -n1)" --no-document
+
   build_line "** bundle installing dependencies"
   bundle install --binstubs
-
-  # build_line "** installing the app gem itself"
-  # gem install "${HAB_CACHE_SRC_PATH}/${pkg_filename}" --no-document
 }
 
 do_install() {


### PR DESCRIPTION
Mostly to do with writing out the bundler config for the build to .bundle/config instead of environment variables.

Also, don't pull in the Habitat core/bundler package anymore. Bundler is ...bundled... with Ruby now. If a different version of bundler is required, install a specific version with gem install during do_build() instead of relying on a Habitat package.
