### PR TITLE
fix the display of !help

### DIFF
--- a/lib/linkbot/plugin.rb
+++ b/lib/linkbot/plugin.rb
@@ -61,7 +61,7 @@ module Linkbot
     end
 
     def help(message = nil)
-      @help = message if !message.nil?
+      @help = message.chomp if !message.nil?
       @help
     end
 

--- a/plugins/help.rb
+++ b/plugins/help.rb
@@ -6,10 +6,13 @@ class Helper < Linkbot::Plugin
 
   def on_message(message, matches)
     messages = []
-    Linkbot::Plugin.plugins.each {|k,v|
-      if(v[:handlers][message.type] && v[:ptr].respond_to?(:help) && !v[:ptr].help.nil?)
+    Linkbot::Plugin.plugins.each {|plugin|
+      if( !plugin.help.nil? &&
+          plugin.handlers &&
+          plugin.handlers[message.type] )
+
         begin
-          messages << v[:ptr].help
+          messages << plugin.help
         rescue => e
           Linkbot.log.error "Helper plugin #{e.inspect}"
           Linkbot.log.error e.backtrace.join("\n")


### PR DESCRIPTION
The whole ptr system went away during [the Great Plugin Refactoring](https://github.com/markolson/linkbot/pull/78).

`Linkbot::Plugin.plugins` is now an array of plugin instances. Walk that collection and prioritize checking for help text first before checking whether the plugin has a handler.

Also, some plugins have multiline HEREDOCs for their help text, so chomp that last newline, eh?
