### PR TITLE
now it's URI.decode -> Addressable::URI.unescape

### DIFF
--- a/plugins/links.rb
+++ b/plugins/links.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+require 'addressable/uri'
 require 'uri'
 
 class Links < Linkbot::Plugin
@@ -31,7 +32,7 @@ class Links < Linkbot::Plugin
     # So, split on the pipe and take the first thing until we get around to
     # chopping up that regex
     url = matches[0].split('|')[0]
-    url = URI.decode(url)
+    url = Addressable::URI.unescape(url)
     uri = URI.parse(url)
 
     # First, make sure this is a HTTP or HTTPS scheme

--- a/plugins/urban.rb
+++ b/plugins/urban.rb
@@ -11,7 +11,7 @@ class Define < Linkbot::Plugin
     word = Addressable::URI.escape(match[0])
     doc = JSON.parse(http_get("http://www.urbandictionary.com/iphone/search/define?term=#{word}"))
     if doc["result_type"] == "exact"
-      "\"#{URI.decode(word)}\": " + doc["list"][0]["definition"] + "\n" + "Example usage: " + doc["list"][0]["example"]
+      "\"#{Addressable::URI.unescape(word)}\": " + doc["list"][0]["definition"] + "\n" + "Example usage: " + doc["list"][0]["example"]
     else
       "No match!"
     end


### PR DESCRIPTION
More `URI` replacements with `Addressable::URI`.

![Address me.](https://i.kym-cdn.com/entries/icons/original/000/055/353/amcovergood.jpg)
